### PR TITLE
Simplify the main layout to use CSS grids and BootStrap card-deck

### DIFF
--- a/live.dot.net/LiveStandup.Web/Pages/Index.cshtml
+++ b/live.dot.net/LiveStandup.Web/Pages/Index.cshtml
@@ -76,7 +76,7 @@
     </div>
 </div>
 
-<div class="row">
+<div class="card-deck grid-deck">
     @foreach (var show in Model.Shows)
     {
 
@@ -85,8 +85,7 @@
             continue;
         }
 
-    <div class="col-sm-6 col-md-4 pb-4">
-        <div class="card shadow youtube-show bottom-buffer h-100">
+        <div class="card shadow youtube-show">
             <a href="@Model.Url" title="Watch this episode">
                 <div>
                     <img src="@show.ThumbnailUrl" class="card-img-top" alt="@show.Title">
@@ -109,15 +108,14 @@
                     <p><span class="badge badge-pill p-2 pr-3 pl-3 badge-primary">@show.Category</span></p>
                 }
 
-                <p><h5 class="card-title">@show.DisplayTitle</h5></p>
+                <h5 class="card-title">@show.DisplayTitle</h5>
                 <a href="@show.Url" class="btn btn-primary">Go somewhere</a>
             </div>
             <div class="card-footer text-muted text-center">
                 @show.ScheduledStartTimeHumanized
             </div>
         </div>
-    </div>
-     }
+      }
 </div>
 
 

--- a/live.dot.net/LiveStandup.Web/wwwroot/css/site.css
+++ b/live.dot.net/LiveStandup.Web/wwwroot/css/site.css
@@ -115,6 +115,12 @@ body {
     }
 }*/
 
+.grid-deck {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-gap: 2.5rem 0.5rem;
+}
+
 .youtube-show > a > div {
     background: #000;
 }
@@ -141,10 +147,6 @@ body {
 
 .liveshow-embed img:hover {
     opacity: .6;
-}
-
-.bottom-buffer {
-    margin-bottom: 30px;
 }
 
 .fa-twitch {


### PR DESCRIPTION
We were so close on the last stream.

The secret to getting multiple rows working appears to be to mix both card-deck and CSS grids together.