### PR TITLE
Added target blank to episode link

### DIFF
--- a/live.dot.net/LiveStandup.Web/Pages/Index.cshtml
+++ b/live.dot.net/LiveStandup.Web/Pages/Index.cshtml
@@ -87,7 +87,7 @@
 
     <div class="col-sm-6 col-md-4 pb-4">
         <div class="card shadow youtube-show bottom-buffer h-100">
-            <a href="@show.Url" title="Watch this episode">
+            <a href="@show.Url" target="_blank" title="Watch this episode">
                 <div>
                     <img src="@show.ThumbnailUrl" class="card-img-top" alt="@show.Title">
                 </div>


### PR DESCRIPTION
It makes more sense UX wise, that the episodes open as a new tab/window instead of redirecting, making you need to go back to the website (And on mobile this could mean the customer needs to wait for load times again)